### PR TITLE
Fix launcher build enviroment

### DIFF
--- a/003-cosmic/deps/launcher/launcher.SlackBuild
+++ b/003-cosmic/deps/launcher/launcher.SlackBuild
@@ -12,6 +12,10 @@ set -e
 mkdir -p $TMP $PKG
 cd $TMP
 
+patch -Np1 -i $CWD/use-libdirsuffix.patch
+sed -i "s|base-dir / 'lib'|base-dir / 'lib${SYSTEM_BITS}'|g" justfile
+sed -i "s|@LIBDIRSUFFIX@|${SYSTEM_BITS}|" src/lib.rs
+
 git clone https://github.com/pop-os/$PRGNAM
 cd $PRGNAM
 VERSION=$(git log -1 --date=format:"%Y%m%d" --format="%ad")

--- a/003-cosmic/deps/launcher/launcher.SlackBuild
+++ b/003-cosmic/deps/launcher/launcher.SlackBuild
@@ -12,13 +12,13 @@ set -e
 mkdir -p $TMP $PKG
 cd $TMP
 
-patch -Np1 -i $CWD/use-libdirsuffix.patch
-sed -i "s|base-dir / 'lib'|base-dir / 'lib${SYSTEM_BITS}'|g" justfile
-sed -i "s|@LIBDIRSUFFIX@|${SYSTEM_BITS}|" src/lib.rs
-
 git clone https://github.com/pop-os/$PRGNAM
 cd $PRGNAM
 VERSION=$(git log -1 --date=format:"%Y%m%d" --format="%ad")
+
+patch -Np1 -i $CWD/use-libdirsuffix.patch
+sed -i "s|base-dir / 'lib'|base-dir / 'lib${SYSTEM_BITS}'|g" justfile
+sed -i "s|@LIBDIRSUFFIX@|${SYSTEM_BITS}|" src/lib.rs
 
 ls rust-toolchain* 1> /dev/null 2>&1 && rm rust-toolchain*
 just build-release --target x86_64-unknown-linux-gnu

--- a/003-cosmic/deps/launcher/use-libdirsuffix.patch
+++ b/003-cosmic/deps/launcher/use-libdirsuffix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib.rs b/src/lib.rs
+index c63fb70..49378ee 100644
+--- a/src/lib.rs
++++ b/src/lib.rs
+@@ -19,7 +19,7 @@ pub const LOCAL_PLUGINS: &str = concatcp!(LOCAL, "/plugins");
+ pub const SYSTEM: &str = "/etc/pop-launcher";
+ pub const SYSTEM_PLUGINS: &str = concatcp!(SYSTEM, "/plugins");
+ 
+-pub const DISTRIBUTION: &str = "/usr/lib/pop-launcher";
++pub const DISTRIBUTION: &str = "/usr/lib@LIBDIRSUFFIX@/pop-launcher";
+ pub const DISTRIBUTION_PLUGINS: &str = concatcp!(DISTRIBUTION, "/plugins");
+ 
+ pub const PLUGIN_PATHS: &[&str] = &[LOCAL_PLUGINS, SYSTEM_PLUGINS, DISTRIBUTION_PLUGINS];


### PR DESCRIPTION
launcher does not respect the LIBDIRSUFFIX atleast on Slackware. On Porteux we need to respect the SYSTEM_BITS which would be the same and make sure that files are where they belong and that they are found and useable.